### PR TITLE
Add support for non native chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here is an example of how you would provide such service:
     const myOwnExplorerAPI: ExplorerAPI = {
       serviceURL: 'path/to/distant/api', // you may need to provide identification details here according to your service pattern
       priority: 0, // this is to decide if this gets called before the out-of-the-box services. 0 means your custom service is going to be called first, use 1 if you prefer the default explorers to be called first.
-      parsingFunction: function (serviceResponse): TransactionData { // only define this function when referring to a custom explorer
+      parsingFunction: function ({ jsonResponse: serviceReponse }: IParsingFunctionAPI): TransactionData { // only define this function when referring to a custom explorer
         // parse your service response in order to return the following information:
         return {
           remoteHash,
@@ -112,7 +112,7 @@ You will need to additionally provide your own lookup function. Contrary to rest
           priority: 0,
           apiType: 'rpc',
           chainType: 'evm',
-          parsingFunction: function (serverUrl, transactionId): TransactionData { // note that function signature is different than for REST parsingFunctions
+          parsingFunction: function ({ serverUrl, transactionId }: IParsingFunctionAPI): TransactionData { // note that function signature is different than for REST parsingFunctions
             // your call to the `serverUrl` with the `transaction` id
             // parse your service response in order to return the following information:
             return {

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ A jsonld signature implementation to support MerkleProof2019 verification in Ver
 ## NOTE
 
 To make use of this package, consumers need to modify the [security-context](https://www.npmjs.com/package/security-context) 
-package locally as MerkleProof2019 is not yet a registered signature mechanism. A PR is currently pending approval for merging
-into the V3 vocab.
+package locally as MerkleProof2019 is not part of the current npm distribution. Another solution is to install from github and use the v3-unstable vocab.
 
 ## Usage
 
 This package is currently designed to work with [vc.js](https://github.com/digitalbazaar/vc-js) in order to 
-verify Blockcerts V3 (based on the Verifiable Credentials specs) definitions.
+verify MerkleProof2019 signed documents.
   
 You will need to wrap the certificate with the Signature Suite:
 
@@ -19,7 +18,7 @@ You will need to wrap the certificate with the Signature Suite:
         ...
     };
 
-    const verificationSuite = new MerkleProof2019({ blockcertsDocument: myBlockcertsV3Definition });
+    const verificationSuite = new MerkleProof2019({ document: myBlockcertsV3Definition });
 ```
 
 In the case of vc.js, you would then pass this suite to the `verify` method, through the `suite` parameter.
@@ -28,14 +27,102 @@ In the case of vc.js, you would then pass this suite to the `verify` method, thr
 The verification principle of MerkleProof2019 is to compare the distant hash of the document 
 (the one saved on the blockchain) with the hash of the local document being verified.
 
-Since this is what [cert-verifier-js](https://github.com/blockchain-certificates/cert-verifier-js) also does, we are 
-leveraging the existing logic to be used by this package.
+## Anchoring chains
+MerkleProof2019 verification as provided by Blockcerts does out of the box verification for Bitcoin (mainnet and testnet) and Ethereum (main and tests), using a set of
+public explorers.
 
-## TODO
-Since the point above is doing a bit more than it should (the verification of the blockcerts would also 
-encompass things like issuer profile and credential status), it could be good to abstract the part about proof verification
-in this package only and make cert-issuer-js a consumer of this package, rather than the other way around. 
+### REST APIs
+By default this library provides some blockchain explorers to retrieve the transaction data associated with a proof. They are:
+- For Bitcoin
+    - [Bitpay](https://bitpay.com/insight)
+    - [Blockcypher](https://blockcypher.com)
+    - [Blockexplorer](https://blockexplorer.com). To confirm if still active
+    - [Blockstream](https://blockstream.info)
+- For Ethereum
+    - [Blockcypher](https://blockcypher.com)
+    - [Etherscan](https://etherscan.io/)
 
-However one could argue that verifying the whole document is also valid, especially that vc.js (for instance) wouldn't 
-necessarily know how to verify the business rules of a blockcerts v3.
- 
+
+You may provide your own explorer or even overwrite the existing ones. This is useful if you have a paid account with one explorer service and you want to ensure a high service availability,
+or if you'd like to provide identification keys to the ones provided by default.
+
+Here is an example of how you would provide such service:
+```js
+    const myBlockcertsV3Definition = {
+        ...
+    };
+
+    const myOwnExplorerAPI: ExplorerAPI = {
+      serviceURL: 'path/to/distant/api', // you may need to provide identification details here according to your service pattern
+      priority: 0, // this is to decide if this gets called before the out-of-the-box services. 0 means your custom service is going to be called first, use 1 if you prefer the default explorers to be called first.
+      parsingFunction: function (serviceResponse): TransactionData { // only define this function when referring to a custom explorer
+        // parse your service response in order to return the following information:
+        return {
+          remoteHash,
+          issuingAddress,
+          time,
+          revokedAddresses
+        }
+      }   
+    };
+    const options = {
+      explorerAPIs: [myOwnExplorerAPI]
+    };
+
+    const verificationSuite = new MerkleProof2019({ document: myBlockcertsV3Definition, options });
+```
+
+## RPCs
+In an alpha implementation, it is now possible to verify transaction of non natively supported chains, using RPC calls.
+If such is your case, 2 options are offered to you:
+
+#### Your chain is compatible with EVM or BTC
+In that case you can take advantage of the built-ins lookup functions. You only need to provide the url to the RPC service you want to use and the `chainType` property to decide which
+lookup function to use:
+
+```js
+    const myBlockcertsV3Definition = {
+        ...
+    };
+
+    const options = {
+        explorerAPIs: [{
+          serviceURL: 'https://rpc-mumbai.maticvigil.com/',
+          priority: 0,
+          apiType: 'rpc',
+          chainType: 'evm'
+        }]
+      };
+    const verificationSuite = new MerkleProof2019({ document: myBlockcertsV3Definition, options });
+```
+
+#### Your chain is not compatible with EVM or BTC
+NOTE: you can use this approach to modify the provided RPC lookup functions.
+
+You will need to additionally provide your own lookup function. Contrary to rest APIs in this package, the parsing function needs to make the calls to the RPC service by itself.  
+
+```js
+    const myBlockcertsV3Definition = {
+        ...
+    };
+
+    const options = {
+        explorerAPIs: [{
+          serviceURL: 'https://rpc-mumbai.maticvigil.com/',
+          priority: 0,
+          apiType: 'rpc',
+          chainType: 'evm',
+          parsingFunction: function (serverUrl, transactionId): TransactionData { // note that function signature is different than for REST parsingFunctions
+            // your call to the `serverUrl` with the `transaction` id
+            // parse your service response in order to return the following information:
+            return {
+              remoteHash,
+              issuingAddress,
+              time,
+              revokedAddresses
+            }
+          }
+        }]
+      };
+    const verificationSuite = new MerkleProof2019({ document: myBlockcertsV3Definition, options });
+```

--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -88,16 +88,17 @@ export class MerkleProof2019 extends LinkedDataProof {
       throw new Error('The passed document is not signed.');
     }
 
-    if (proof.type !== this.type) {
-      throw new Error(`Incorrect proof type passed for verification. Expected: ${this.type}, Received: ${proof.type}`);
-    }
-
     const base58Decoder = new Decoder(proof.proofValue);
     this.proof = base58Decoder.decode();
   }
 
-  async verifyProof (): Promise<MerkleProof2019VerificationResult> {
-    let verified: boolean = false;
+  // DO NOT PUT THIS IN PROD
+  matchProof ({ proof }): boolean {
+    return proof.type === this.type || proof.type === 'EcdsaSecp256k1Signature2019';
+  }
+
+  async verifyProof (): Promise<MerkleProof2019VerificationResult> { // TODO: define return type
+    let verified: boolean;
     let error: string = '';
     try {
       this.validateTransactionId();
@@ -144,7 +145,7 @@ export class MerkleProof2019 extends LinkedDataProof {
   private async fetchTransactionData (): Promise<void> {
     this.txData = await lookForTx({
       transactionId: this.transactionId,
-      chain: this.chain.code,
+      chain: this.chain?.code,
       explorerAPIs: prepareExplorerAPIs(this.explorerAPIs)
     });
   }

--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -3,7 +3,7 @@ import jsigs from 'jsonld-signatures';
 import { DecodedProof, JSONLDProof } from './models/Proof';
 import getTransactionId from './helpers/getTransactionId';
 import isTransactionIdValid from './inspectors/isTransactionIdValid';
-import lookForTx, { prepareExplorerAPIs } from './helpers/lookForTx';
+import lookForTx from './helpers/lookForTx';
 import { ExplorerAPI } from './models/Explorers';
 import { IBlockchainObject } from './constants/blockchains';
 import getChain from './helpers/getChain';
@@ -11,6 +11,7 @@ import { TransactionData } from './models/TransactionData';
 import computeLocalHash from './inspectors/computeLocalHash';
 import ensureHashesEqual from './inspectors/ensureHashesEqual';
 import ensureMerkleRootEqual from './inspectors/ensureMerkleRootEqual';
+import { prepareExplorerAPIs } from './explorers';
 const { LinkedDataProof } = jsigs.suites;
 
 export interface MerkleProof2019Options {

--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -93,11 +93,6 @@ export class MerkleProof2019 extends LinkedDataProof {
     this.proof = base58Decoder.decode();
   }
 
-  // DO NOT PUT THIS IN PROD
-  matchProof ({ proof }): boolean {
-    return proof.type === this.type || proof.type === 'EcdsaSecp256k1Signature2019';
-  }
-
   async verifyProof (): Promise<MerkleProof2019VerificationResult> { // TODO: define return type
     let verified: boolean;
     let error: string = '';

--- a/src/explorers/bitcoin/bitpay.ts
+++ b/src/explorers/bitcoin/bitpay.ts
@@ -5,9 +5,10 @@ import { TransactionData } from '../../models/TransactionData';
 import { TRANSACTION_APIS, TRANSACTION_ID_PLACEHOLDER } from '../../constants/api';
 import CONFIG from '../../constants/config';
 import { BLOCKCHAINS } from '../../constants/blockchains';
+import { IParsingFunctionAPI } from '../explorer';
 
 // TODO: use tests/explorers/mocks/mockBitpayResponse as type
-function parsingFunction (jsonResponse): TransactionData {
+function parsingFunction ({ jsonResponse }: IParsingFunctionAPI): TransactionData {
   if (jsonResponse.confirmations < CONFIG.MininumConfirmations) {
     throw new Error('Number of transaction confirmations were less than the minimum required, according to Bitpay API');
   }

--- a/src/explorers/bitcoin/blockcypher.ts
+++ b/src/explorers/bitcoin/blockcypher.ts
@@ -5,9 +5,10 @@ import { TransactionData } from '../../models/TransactionData';
 import { TRANSACTION_APIS, TRANSACTION_ID_PLACEHOLDER } from '../../constants/api';
 import CONFIG from '../../constants/config';
 import { BLOCKCHAINS } from '../../constants/blockchains';
+import { IParsingFunctionAPI } from '../explorer';
 
 // TODO: use tests/explorers/mocks/mockBlockcypher as type
-function parsingFunction (jsonResponse): TransactionData {
+function parsingFunction ({ jsonResponse }: IParsingFunctionAPI): TransactionData {
   if (jsonResponse.confirmations < CONFIG.MininumConfirmations) {
     throw new Error('Number of transaction confirmations were less than the minimum required, according to Blockcypher API');
   }

--- a/src/explorers/bitcoin/blockexplorer.ts
+++ b/src/explorers/bitcoin/blockexplorer.ts
@@ -5,9 +5,10 @@ import { TransactionData } from '../../models/TransactionData';
 import { TRANSACTION_APIS, TRANSACTION_ID_PLACEHOLDER } from '../../constants/api';
 import { BLOCKCHAINS } from '../../constants/blockchains';
 import CONFIG from '../../constants/config';
+import { IParsingFunctionAPI } from '../explorer';
 
 // TODO: use tests/explorers/mocks/mockBlockexplorer as type
-function parsingFunction (jsonResponse): TransactionData {
+function parsingFunction ({ jsonResponse }: IParsingFunctionAPI): TransactionData {
   if (jsonResponse.confirmations < CONFIG.MininumConfirmations) {
     throw new Error('Number of transaction confirmations were less than the minimum required, according to Blockexplorer API');
   }

--- a/src/explorers/bitcoin/blockstream.ts
+++ b/src/explorers/bitcoin/blockstream.ts
@@ -4,9 +4,10 @@ import { ExplorerAPI, ExplorerURLs } from '../../models/Explorers';
 import { TransactionData } from '../../models/TransactionData';
 import { TRANSACTION_APIS, TRANSACTION_ID_PLACEHOLDER } from '../../constants/api';
 import { BLOCKCHAINS } from '../../constants/blockchains';
+import { IParsingFunctionAPI } from '../explorer';
 
 // TODO: use tests/explorers/mocks/mockBlockstreamResponse as type
-function parsingFunction (jsonResponse): TransactionData {
+function parsingFunction ({ jsonResponse }: IParsingFunctionAPI): TransactionData {
   if (!jsonResponse.status.confirmed) {
     throw new Error('Number of transaction confirmations were less than the minimum required, according to Blockstream API');
   }

--- a/src/explorers/ethereum/blockcypher.ts
+++ b/src/explorers/ethereum/blockcypher.ts
@@ -6,6 +6,7 @@ import { ExplorerAPI, ExplorerURLs } from '../../models/Explorers';
 import CONFIG from '../../constants/config';
 import { dateToUnixTimestamp } from '../../utils/date';
 import { prependHashPrefix } from '../../utils/prependHashPrefix';
+import { IParsingFunctionAPI } from '../explorer';
 
 const serviceURL: ExplorerURLs = {
   main: `https://api.blockcypher.com/v1/eth/main/txs/${TRANSACTION_ID_PLACEHOLDER}?limit=500`,
@@ -13,7 +14,7 @@ const serviceURL: ExplorerURLs = {
 };
 
 // TODO: use tests/explorers/mocks/mockBlockcypherResponse as type
-function parsingFunction (jsonResponse): TransactionData {
+function parsingFunction ({ jsonResponse }: IParsingFunctionAPI): TransactionData {
   if (jsonResponse.confirmations < CONFIG.MininumConfirmations) {
     // TODO: not tested
     throw new Error('Not enough');

--- a/src/explorers/ethereum/etherscan.ts
+++ b/src/explorers/ethereum/etherscan.ts
@@ -6,6 +6,7 @@ import { TransactionData } from '../../models/TransactionData';
 import { TRANSACTION_APIS, TRANSACTION_ID_PLACEHOLDER } from '../../constants/api';
 import { ExplorerAPI, ExplorerURLs } from '../../models/Explorers';
 import CONFIG from '../../constants/config';
+import { IParsingFunctionAPI } from '../explorer';
 
 const MAIN_API_BASE_URL = 'https://api.etherscan.io/api?module=proxy';
 const TEST_API_BASE_URL = 'https://api-ropsten.etherscan.io/api?module=proxy';
@@ -15,7 +16,7 @@ const serviceURL: ExplorerURLs = {
 };
 
 // TODO: use tests/explorers/mocks/mockEtherscanResponse as type
-async function parsingFunction (jsonResponse, chain: SupportedChains, key: string, keyPropertyName: string): Promise<TransactionData> {
+async function parsingFunction ({ jsonResponse, chain, key, keyPropertyName }: IParsingFunctionAPI): Promise<TransactionData> {
   const getBlockByNumberServiceUrls: Partial<ExplorerAPI> = {
     serviceURL: {
       main: `${MAIN_API_BASE_URL}&action=eth_getBlockByNumber&boolean=true&tag=${TRANSACTION_ID_PLACEHOLDER}`,

--- a/src/explorers/explorer.ts
+++ b/src/explorers/explorer.ts
@@ -11,7 +11,7 @@ import { explorerApi as BlockCypherBTCApi } from './bitcoin/blockcypher';
 import { explorerApi as BitPayApi } from './bitcoin/bitpay';
 
 export type TExplorerFunctionsArray = Array<{
-  getTxData: (transactionId: string, chain: SupportedChains) => Promise<TransactionData>;
+  getTxData: (transactionId: string, chain?: SupportedChains) => Promise<TransactionData>;
   priority?: number;
 }>;
 export type TExplorerParsingFunction = ((jsonResponse, chain?: SupportedChains, key?: string, keyPropertyName?: string) => TransactionData) |

--- a/src/explorers/explorer.ts
+++ b/src/explorers/explorer.ts
@@ -14,8 +14,16 @@ export type TExplorerFunctionsArray = Array<{
   getTxData: (transactionId: string, chain?: SupportedChains) => Promise<TransactionData>;
   priority?: number;
 }>;
-export type TExplorerParsingFunction = ((jsonResponse, chain?: SupportedChains, key?: string, keyPropertyName?: string) => TransactionData) |
-((jsonResponse, chain?: SupportedChains, key?: string, keyPropertyName?: string) => Promise<TransactionData>);
+export interface IParsingFunctionAPI {
+  jsonResponse?: any; // the response from the service when called as rest
+  chain?: SupportedChains; // TODO: look at how to deprecate this. Only used in etherscan
+  key?: string; // identification key to pass to the service -> TODO: can this be merged into the serviceUrl? Only used in etherscan
+  keyPropertyName?: string; // the key property to associate with the identification key -> TODO: can this be merged into the serviceUrl? Only used in etherscan
+  transactionId?: string; // when using in RPCs we pass the tx id to look up since these functions are responsible for service lookup
+  serviceUrl?: string; // the distant service url
+}
+export type TExplorerParsingFunction = ((data: IParsingFunctionAPI) => TransactionData) |
+((data: IParsingFunctionAPI) => Promise<TransactionData>);
 
 export function explorerFactory (TransactionAPIArray: ExplorerAPI[]): TExplorerFunctionsArray {
   return TransactionAPIArray
@@ -40,7 +48,11 @@ export async function getTransactionFromApi (
 
   try {
     const response = await request({ url: requestUrl });
-    return await explorerAPI.parsingFunction(JSON.parse(response), chain, explorerAPI.key, explorerAPI.keyPropertyName);
+    return await explorerAPI.parsingFunction({
+      jsonResponse: JSON.parse(response),
+      chain,
+      ...explorerAPI
+    });
   } catch (err) {
     throw new Error('Unable to get remote hash');
   }

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -78,7 +78,10 @@ function rpcFactory (explorerAPIs: ExplorerAPI[]): TExplorerFunctionsArray {
     return explorerAPI;
   }).map(explorerAPI => (
     {
-      getTxData: async (transactionId) => await explorerAPI.parsingFunction(explorerAPI.serviceURL, transactionId),
+      getTxData: async (transactionId) => await explorerAPI.parsingFunction({
+        ...explorerAPI,
+        transactionId
+      }),
       priority: explorerAPI.priority
     }
   ));

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -69,10 +69,10 @@ export function getDefaultExplorers (explorerAPIs?: ExplorerAPI[]): TDefaultExpl
   };
 }
 
-function rpcFactory (explorerAPIs: ExplorerAPI[]) {
+function rpcFactory (explorerAPIs: ExplorerAPI[]): TExplorerFunctionsArray {
   return explorerAPIs.map(explorerAPI => {
     if (!explorerAPI.parsingFunction) {
-      explorerAPI.parsingFunction = ethereumRPCParsingFunction
+      explorerAPI.parsingFunction = ethereumRPCParsingFunction;
     }
     return explorerAPI;
   }).map(explorerAPI => (
@@ -83,8 +83,8 @@ function rpcFactory (explorerAPIs: ExplorerAPI[]) {
   ));
 }
 
-export function getRPCExplorers (customExplorerAPIs?: ExplorerAPI[]) {
+export function getRPCExplorers (customExplorerAPIs?: ExplorerAPI[]): Partial<TExplorerAPIs> {
   return {
     custom: rpcFactory(customExplorerAPIs)
-  }
+  };
 }

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -6,6 +6,7 @@ import {
 } from './explorer';
 import { TRANSACTION_APIS } from '../constants/api';
 import { ExplorerAPI } from '../models/Explorers';
+import { ethereumRPCParsingFunction } from './rpc/ethereum';
 
 export interface TDefaultExplorersPerBlockchain {
   bitcoin: TExplorerFunctionsArray;
@@ -66,4 +67,23 @@ export function getDefaultExplorers (explorerAPIs?: ExplorerAPI[]): TDefaultExpl
     bitcoin: explorerFactory(overwriteDefaultExplorers(explorerAPIs, BitcoinExplorers)),
     ethereum: explorerFactory(overwriteDefaultExplorers(explorerAPIs, EthereumExplorers))
   };
+}
+
+function rpcFactory (explorerAPIs: ExplorerAPI[]) {
+  return explorerAPIs.map(explorerAPI => (
+    {
+      getTxData: async (transactionId) => await explorerAPI.parsingFunction(explorerAPI.serviceURL, transactionId),
+      priority: explorerAPI.priority
+    }
+  ));
+}
+
+export function getRPCExplorers (explorerAPIs?: ExplorerAPI[]) {
+  return {
+    ethereum: rpcFactory([{
+      serviceURL: 'https://rpc-mumbai.maticvigil.com/',
+      priority: 0,
+      parsingFunction: ethereumRPCParsingFunction
+    }])
+  }
 }

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -7,6 +7,7 @@ import {
 import { TRANSACTION_APIS } from '../constants/api';
 import { ExplorerAPI } from '../models/Explorers';
 import { ethereumRPCParsingFunction } from './rpc/ethereum';
+import { bitcoinRPCParsingFunction } from './rpc/bitcoin';
 
 export interface TDefaultExplorersPerBlockchain {
   bitcoin: TExplorerFunctionsArray;
@@ -72,7 +73,7 @@ export function getDefaultExplorers (explorerAPIs?: ExplorerAPI[]): TDefaultExpl
 function rpcFactory (explorerAPIs: ExplorerAPI[]): TExplorerFunctionsArray {
   return explorerAPIs.map(explorerAPI => {
     if (!explorerAPI.parsingFunction) {
-      explorerAPI.parsingFunction = ethereumRPCParsingFunction;
+      explorerAPI.parsingFunction = explorerAPI.chainType === 'btc' ? bitcoinRPCParsingFunction : ethereumRPCParsingFunction;
     }
     return explorerAPI;
   }).map(explorerAPI => (

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -89,3 +89,18 @@ export function getRPCExplorers (customExplorerAPIs?: ExplorerAPI[]): Partial<TE
     custom: rpcFactory(customExplorerAPIs)
   };
 }
+
+export function prepareExplorerAPIs (customExplorerAPIs: ExplorerAPI[]): TExplorerAPIs {
+  const { bitcoin, ethereum } = getDefaultExplorers(customExplorerAPIs);
+  const { custom: rpcCustomExplorers } = getRPCExplorers(customExplorerAPIs.filter(e => e.apiType === 'rpc'));
+  const restCustomExplorers = explorerFactory(customExplorerAPIs.filter(e => e.apiType !== 'rpc'));
+
+  return {
+    bitcoin,
+    ethereum,
+    custom: [
+      ...rpcCustomExplorers,
+      ...restCustomExplorers
+    ]
+  };
+}

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -70,7 +70,12 @@ export function getDefaultExplorers (explorerAPIs?: ExplorerAPI[]): TDefaultExpl
 }
 
 function rpcFactory (explorerAPIs: ExplorerAPI[]) {
-  return explorerAPIs.map(explorerAPI => (
+  return explorerAPIs.map(explorerAPI => {
+    if (!explorerAPI.parsingFunction) {
+      explorerAPI.parsingFunction = ethereumRPCParsingFunction
+    }
+    return explorerAPI;
+  }).map(explorerAPI => (
     {
       getTxData: async (transactionId) => await explorerAPI.parsingFunction(explorerAPI.serviceURL, transactionId),
       priority: explorerAPI.priority
@@ -80,10 +85,6 @@ function rpcFactory (explorerAPIs: ExplorerAPI[]) {
 
 export function getRPCExplorers (explorerAPIs?: ExplorerAPI[]) {
   return {
-    ethereum: rpcFactory([{
-      serviceURL: 'https://rpc-mumbai.maticvigil.com/',
-      priority: 0,
-      parsingFunction: ethereumRPCParsingFunction
-    }])
+    ethereum: rpcFactory(explorerAPIs)
   }
 }

--- a/src/explorers/index.ts
+++ b/src/explorers/index.ts
@@ -83,8 +83,8 @@ function rpcFactory (explorerAPIs: ExplorerAPI[]) {
   ));
 }
 
-export function getRPCExplorers (explorerAPIs?: ExplorerAPI[]) {
+export function getRPCExplorers (customExplorerAPIs?: ExplorerAPI[]) {
   return {
-    ethereum: rpcFactory(explorerAPIs)
+    custom: rpcFactory(customExplorerAPIs)
   }
 }

--- a/src/explorers/rpc/bitcoin.ts
+++ b/src/explorers/rpc/bitcoin.ts
@@ -2,8 +2,9 @@ import { TransactionData } from '../../models/TransactionData';
 import { stripHashPrefix } from '../../utils/stripHashPrefix';
 import { timestampToDateObject } from '../../utils/date';
 import { request } from '../../services/request';
+import { IParsingFunctionAPI } from '../explorer';
 
-export async function bitcoinRPCParsingFunction (serverUrl: string, transactionId: string): Promise<TransactionData> {
+export async function bitcoinRPCParsingFunction ({ serviceUrl, transactionId }: IParsingFunctionAPI): Promise<TransactionData> {
   const getRawTransactionParams = {
     method: 'getrawtransaction',
     jsonrpc: '2.0',
@@ -14,7 +15,7 @@ export async function bitcoinRPCParsingFunction (serverUrl: string, transactionI
     ]
   };
   const resultRawTransaction = await request({
-    url: serverUrl,
+    url: serviceUrl,
     body: getRawTransactionParams,
     method: 'POST'
   });

--- a/src/explorers/rpc/bitcoin.ts
+++ b/src/explorers/rpc/bitcoin.ts
@@ -1,0 +1,38 @@
+import { TransactionData } from '../../models/TransactionData';
+import { stripHashPrefix } from '../../utils/stripHashPrefix';
+import { timestampToDateObject } from '../../utils/date';
+import { request } from '../../services/request';
+
+export async function bitcoinRPCParsingFunction (serverUrl: string, transactionId: string): Promise<TransactionData> {
+  const getRawTransactionParams = {
+    method: 'getrawtransaction',
+    jsonrpc: '2.0',
+    id: 'rpctest',
+    params: [
+      transactionId,
+      true
+    ]
+  };
+  const resultRawTransaction = await request({
+    url: serverUrl,
+    body: getRawTransactionParams,
+    method: 'POST'
+  });
+
+  const transaction = JSON.parse(resultRawTransaction).result;
+  const issuingAddress = transaction.vout[0].scriptPubKey.addresses[0];
+  const remoteHash = stripHashPrefix(transaction.vout[1].scriptPubKey.asm, ['6a20', 'OP_RETURN ']);
+  const time = timestampToDateObject(transaction.blocktime);
+  // after research, this only seems to be used in v1.2 of blockcerts.
+  const revokedAddresses = transaction.vout
+    .filter(output => !!output.scriptPubKey.addresses)
+    .map(output => output.scriptPubKey.addresses)
+    .flat();
+
+  return {
+    issuingAddress,
+    remoteHash,
+    time,
+    revokedAddresses
+  };
+}

--- a/src/explorers/rpc/ethereum.ts
+++ b/src/explorers/rpc/ethereum.ts
@@ -1,0 +1,52 @@
+import { TransactionData } from '../../models/TransactionData';
+import { stripHashPrefix } from '../../utils/stripHashPrefix';
+import { request } from '../../services/request';
+
+export async function ethereumRPCParsingFunction (serverUrl: string, transactionId: string): Promise<TransactionData> {
+  const transactionByHashParams = {
+    method: 'eth_getTransactionByHash',
+    jsonrpc: '2.0',
+    id: 'getbyhash',
+    params: [
+      '0x' + transactionId
+    ]
+  };
+  const resultTransactionByHash = await request({
+    url: serverUrl,
+    body: transactionByHashParams,
+    method: 'POST'
+  });
+
+  const transactionByHash = JSON.parse(resultTransactionByHash);
+
+  const blockByNumberParams = {
+    method: 'eth_getBlockByNumber',
+    jsonrpc: '2.0',
+    id: 'blockbynumber',
+    params: [
+      transactionByHash.result.blockNumber,
+      true
+    ]
+  };
+  const resultBlockByNumber = await request({
+    url: serverUrl,
+    body: blockByNumberParams,
+    method: 'POST'
+  });
+  // check confirm validity see cvjs etherscan
+
+  const block = JSON.parse(resultBlockByNumber);
+
+  const txData = transactionByHash.result;
+  const blockData = block.result;
+  const time = new Date(parseInt(blockData.timestamp, 16) * 1000);
+  const issuingAddress = txData.from;
+  const remoteHash = stripHashPrefix(txData.input, ['0x']); // remove '0x'
+
+  return {
+    remoteHash,
+    issuingAddress,
+    time,
+    revokedAddresses: []
+  };
+}

--- a/src/explorers/rpc/ethereum.ts
+++ b/src/explorers/rpc/ethereum.ts
@@ -1,8 +1,9 @@
 import { TransactionData } from '../../models/TransactionData';
 import { stripHashPrefix } from '../../utils/stripHashPrefix';
 import { request } from '../../services/request';
+import { IParsingFunctionAPI } from '../explorer';
 
-export async function ethereumRPCParsingFunction (serverUrl: string, transactionId: string): Promise<TransactionData> {
+export async function ethereumRPCParsingFunction ({ serviceUrl, transactionId }: IParsingFunctionAPI): Promise<TransactionData> {
   const transactionByHashParams = {
     method: 'eth_getTransactionByHash',
     jsonrpc: '2.0',
@@ -12,7 +13,7 @@ export async function ethereumRPCParsingFunction (serverUrl: string, transaction
     ]
   };
   const resultTransactionByHash = await request({
-    url: serverUrl,
+    url: serviceUrl,
     body: transactionByHashParams,
     method: 'POST'
   });
@@ -29,7 +30,7 @@ export async function ethereumRPCParsingFunction (serverUrl: string, transaction
     ]
   };
   const resultBlockByNumber = await request({
-    url: serverUrl,
+    url: serviceUrl,
     body: blockByNumberParams,
     method: 'POST'
   });

--- a/src/helpers/getChain.ts
+++ b/src/helpers/getChain.ts
@@ -19,8 +19,6 @@ function getMerkleRoot2019Chain (anchor): IBlockchainObject {
     const network = dataArray[chainIndex + 1];
     const chainCodeProofValue = supportedChainsMap[chainCode].chainName.toLowerCase() + capitalize(network);
     return getChainObject(chainCodeProofValue);
-  } else {
-    throw new Error('Unsupported anchoring chain.');
   }
 }
 

--- a/src/helpers/lookForTx.ts
+++ b/src/helpers/lookForTx.ts
@@ -70,7 +70,9 @@ function buildQueuePromises (queue, transactionId, chain): any[] {
 }
 
 function buildPromiseRacesQueue (
-  { defaultAPIs, customAPIs }: { defaultAPIs: TExplorerFunctionsArray; customAPIs: TExplorerFunctionsArray }): PromiseRaceQueue {
+  { defaultAPIs, customAPIs }:
+  { defaultAPIs: TExplorerFunctionsArray; customAPIs: TExplorerFunctionsArray }
+): PromiseRaceQueue {
   const promiseRaceQueue = [defaultAPIs];
 
   if (customAPIs?.length) {

--- a/src/helpers/lookForTx.ts
+++ b/src/helpers/lookForTx.ts
@@ -2,10 +2,8 @@ import { SupportedChains, BLOCKCHAINS } from '../constants/blockchains';
 import CONFIG from '../constants/config';
 import PromiseProperRace from './promiseProperRace';
 import { TransactionData } from '../models/TransactionData';
-import { explorerFactory, TExplorerFunctionsArray } from '../explorers/explorer';
-import { getDefaultExplorers, getRPCExplorers, TExplorerAPIs } from '../explorers';
-import { ExplorerAPI } from '../models/Explorers';
-import ensureExplorerAPIValidity from '../utils/ensureExplorerAPIValidity';
+import { TExplorerFunctionsArray } from '../explorers/explorer';
+import { TExplorerAPIs } from '../explorers';
 
 export function getExplorersByChain (chain: SupportedChains, explorerAPIs: TExplorerAPIs): TExplorerFunctionsArray {
   switch (chain) {
@@ -99,21 +97,6 @@ async function runQueueByIndex (queues, index: number, transactionId, chain): Pr
     }
     throw err;
   }
-}
-
-export function prepareExplorerAPIs (customExplorerAPIs: ExplorerAPI[]): TExplorerAPIs {
-  const { bitcoin, ethereum } = getDefaultExplorers(customExplorerAPIs);
-  const { custom: rpcCustomExplorers } = getRPCExplorers(customExplorerAPIs.filter(e => e.apiType === 'rpc'));
-  const restCustomExplorers = explorerFactory(customExplorerAPIs.filter(e => e.apiType !== 'rpc'));
-
-  return {
-    bitcoin,
-    ethereum,
-    custom: [
-      ...rpcCustomExplorers,
-      ...restCustomExplorers
-    ]
-  };
 }
 
 export default async function lookForTx (

--- a/src/helpers/lookForTx.ts
+++ b/src/helpers/lookForTx.ts
@@ -3,7 +3,7 @@ import CONFIG from '../constants/config';
 import PromiseProperRace from './promiseProperRace';
 import { TransactionData } from '../models/TransactionData';
 import { explorerFactory, TExplorerFunctionsArray } from '../explorers/explorer';
-import { getDefaultExplorers, TExplorerAPIs } from '../explorers';
+import { getDefaultExplorers, getRPCExplorers, TExplorerAPIs } from '../explorers';
 import { ExplorerAPI } from '../models/Explorers';
 import ensureExplorerAPIValidity from '../utils/ensureExplorerAPIValidity';
 
@@ -18,9 +18,12 @@ export function getExplorersByChain (chain: SupportedChains, explorerAPIs: TExpl
     case BLOCKCHAINS[SupportedChains.Ethropst].code:
     case BLOCKCHAINS[SupportedChains.Ethrinkeby].code:
       return explorerAPIs.ethereum;
+    default:
+      if (!explorerAPIs.custom.length) {
+        throw new Error('Chain is not natively supported. Use custom explorers to retrieve tx data.');
+      }
+      return explorerAPIs.custom;
   }
-
-  throw new Error('Chain is not natively supported. Use custom explorers to retrieve tx data.');
 }
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -97,13 +100,14 @@ async function runQueueByIndex (queues, index: number, transactionId, chain): Pr
 }
 
 export function prepareExplorerAPIs (customExplorerAPIs: ExplorerAPI[]): TExplorerAPIs {
-  const explorerAPIs: TExplorerAPIs = getDefaultExplorers(customExplorerAPIs);
+  // const explorerAPIs: TExplorerAPIs = getDefaultExplorers(customExplorerAPIs);
+  //
+  // if (ensureExplorerAPIValidity(customExplorerAPIs)) {
+  //   explorerAPIs.custom = explorerFactory(customExplorerAPIs);
+  // }
 
-  if (ensureExplorerAPIValidity(customExplorerAPIs)) {
-    explorerAPIs.custom = explorerFactory(customExplorerAPIs);
-  }
-
-  return explorerAPIs;
+  const explorerAPIs = getRPCExplorers(customExplorerAPIs);
+  return explorerAPIs as any;
 }
 
 export default async function lookForTx (

--- a/src/helpers/lookForTx.ts
+++ b/src/helpers/lookForTx.ts
@@ -19,7 +19,7 @@ export function getExplorersByChain (chain: SupportedChains, explorerAPIs: TExpl
     case BLOCKCHAINS[SupportedChains.Ethrinkeby].code:
       return explorerAPIs.ethereum;
     default:
-      if (!explorerAPIs.custom.length) {
+      if (!explorerAPIs.custom?.length) {
         throw new Error('Chain is not natively supported. Use custom explorers to retrieve tx data.');
       }
       return explorerAPIs.custom;
@@ -104,7 +104,7 @@ async function runQueueByIndex (queues, index: number, transactionId, chain): Pr
 export function prepareExplorerAPIs (customExplorerAPIs: ExplorerAPI[]): TExplorerAPIs {
   const { bitcoin, ethereum } = getDefaultExplorers(customExplorerAPIs);
   const { custom: rpcCustomExplorers } = getRPCExplorers(customExplorerAPIs.filter(e => e.apiType === 'rpc'));
-  const restCustomExplorers = explorerFactory(customExplorerAPIs.filter(e => e.apiType === 'rest'));
+  const restCustomExplorers = explorerFactory(customExplorerAPIs.filter(e => e.apiType !== 'rpc'));
 
   return {
     bitcoin,

--- a/src/helpers/lookForTx.ts
+++ b/src/helpers/lookForTx.ts
@@ -100,14 +100,18 @@ async function runQueueByIndex (queues, index: number, transactionId, chain): Pr
 }
 
 export function prepareExplorerAPIs (customExplorerAPIs: ExplorerAPI[]): TExplorerAPIs {
-  // const explorerAPIs: TExplorerAPIs = getDefaultExplorers(customExplorerAPIs);
-  //
-  // if (ensureExplorerAPIValidity(customExplorerAPIs)) {
-  //   explorerAPIs.custom = explorerFactory(customExplorerAPIs);
-  // }
+  const { bitcoin, ethereum } = getDefaultExplorers(customExplorerAPIs);
+  const { custom: rpcCustomExplorers } = getRPCExplorers(customExplorerAPIs.filter(e => e.apiType === 'rpc'));
+  const restCustomExplorers = explorerFactory(customExplorerAPIs.filter(e => e.apiType === 'rest'));
 
-  const explorerAPIs = getRPCExplorers(customExplorerAPIs);
-  return explorerAPIs as any;
+  return {
+    bitcoin,
+    ethereum,
+    custom: [
+      ...rpcCustomExplorers,
+      ...restCustomExplorers
+    ]
+  };
 }
 
 export default async function lookForTx (

--- a/src/models/Explorers.ts
+++ b/src/models/Explorers.ts
@@ -15,6 +15,10 @@ export interface ExplorerAPI {
   keyPropertyName?: string; // the name of the property
   // apiType: whether the parsing function is calling a rpc or rest method.
   // RPC parsing functions are provided for BTC and ETH (EVM) chains.
-  // defaults to rest
+  // defaults to 'rest'
   apiType?: 'rpc' | 'rest';
+  // This library provides 2 types of RPC call parsing function,
+  // one for Bitcoin ('btc') RPCs and one for Ethereum ('eth', alias 'evm') RPCs.
+  // This option allows the consumer to use one of these functions
+  chainType?: 'btc' | 'evm' | 'eth';
 }

--- a/src/models/Explorers.ts
+++ b/src/models/Explorers.ts
@@ -13,4 +13,5 @@ export interface ExplorerAPI {
   serviceName?: TRANSACTION_APIS; // in case one would want to overload the default explorers
   key?: string; // the user's own key to the service
   keyPropertyName?: string; // the name of the property
+  apiType?: 'rpc' | 'rest'; // whether the parsing function is calling a rpc or rest method. RPC parsing functions are provided for BTC and ETH (EVM) chains
 }

--- a/src/models/Explorers.ts
+++ b/src/models/Explorers.ts
@@ -13,5 +13,8 @@ export interface ExplorerAPI {
   serviceName?: TRANSACTION_APIS; // in case one would want to overload the default explorers
   key?: string; // the user's own key to the service
   keyPropertyName?: string; // the name of the property
-  apiType?: 'rpc' | 'rest'; // whether the parsing function is calling a rpc or rest method. RPC parsing functions are provided for BTC and ETH (EVM) chains
+  // apiType: whether the parsing function is calling a rpc or rest method.
+  // RPC parsing functions are provided for BTC and ETH (EVM) chains.
+  // defaults to rest
+  apiType?: 'rpc' | 'rest';
 }

--- a/src/models/Explorers.ts
+++ b/src/models/Explorers.ts
@@ -19,6 +19,7 @@ export interface ExplorerAPI {
   apiType?: 'rpc' | 'rest';
   // This library provides 2 types of RPC call parsing function,
   // one for Bitcoin ('btc') RPCs and one for Ethereum ('eth', alias 'evm') RPCs.
-  // This option allows the consumer to use one of these functions
+  // This option allows the consumer to use one of these function
+  // defaults to 'eth'
   chainType?: 'btc' | 'evm' | 'eth';
 }

--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -2,7 +2,7 @@ import { XMLHttpRequest as xhrPolyfill } from 'xmlhttprequest';
 
 export interface RequestParameters {
   url: string;
-  method?: 'GET';
+  method?: 'GET' | 'POST';
   body?: any;
 }
 

--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -23,6 +23,7 @@ export async function request (obj: RequestParameters): Promise<string> {
       if (request.status >= 200 && request.status < 300) {
         resolve(request.responseText);
       } else {
+        console.log(request.responseText);
         const failureMessage: string = `Error fetching url:${url}; status code:${request.status}`;
         reject(new Error(failureMessage));
       }

--- a/tests/MerkleProof2019.test.ts
+++ b/tests/MerkleProof2019.test.ts
@@ -28,17 +28,6 @@ describe('MerkleProof2019 test suite', function () {
     });
   });
 
-  describe('given the document is not signed by MerkleProof2019', function () {
-    it('should throw', function () {
-      const unsignedDocument = JSON.parse(JSON.stringify(blockcertsV3Fixture));
-      unsignedDocument.proof.type = 'Not merkle proof 2019';
-      expect(() => {
-        // eslint-disable-next-line no-new
-        new MerkleProof2019({ document: unsignedDocument });
-      }).toThrow('Incorrect proof type passed for verification. Expected: MerkleProof2019, Received: Not merkle proof 2019');
-    });
-  });
-
   describe('given a MerkleProof2019 signed document is passed', function () {
     let instance;
 

--- a/tests/explorers/bitcoin/bitpay.test.ts
+++ b/tests/explorers/bitcoin/bitpay.test.ts
@@ -21,7 +21,7 @@ describe('Bitpay Explorer test suite', function () {
     };
 
     it('should return the transaction data', function () {
-      expect(explorerApi.parsingFunction(mockResponse)).toEqual(assertionTransactionData);
+      expect(explorerApi.parsingFunction({ jsonResponse: mockResponse })).toEqual(assertionTransactionData);
     });
   });
 
@@ -29,7 +29,7 @@ describe('Bitpay Explorer test suite', function () {
     it('should throw the right error', async function () {
       mockResponse.confirmations = 0;
       await expect(async () => {
-        await explorerApi.parsingFunction(mockResponse);
+        await explorerApi.parsingFunction({ jsonResponse: mockResponse });
       }).rejects.toThrowError('Number of transaction confirmations were less than the minimum required, according to Bitpay API');
     });
   });

--- a/tests/explorers/bitcoin/blockcypher.test.ts
+++ b/tests/explorers/bitcoin/blockcypher.test.ts
@@ -21,7 +21,7 @@ describe('Blockcypher Bitcoin Explorer test suite', function () {
     };
 
     it('should return the transaction data', function () {
-      expect(explorerApi.parsingFunction(mockResponse)).toEqual(assertionTransactionData);
+      expect(explorerApi.parsingFunction({ jsonResponse: mockResponse })).toEqual(assertionTransactionData);
     });
   });
 
@@ -29,7 +29,7 @@ describe('Blockcypher Bitcoin Explorer test suite', function () {
     it('should throw the right error', async function () {
       mockResponse.confirmations = 0;
       await expect(async () => {
-        await explorerApi.parsingFunction(mockResponse);
+        await explorerApi.parsingFunction({ jsonResponse: mockResponse });
       }).rejects.toThrowError('Number of transaction confirmations were less than the minimum required, according to Blockcypher API');
     });
   });

--- a/tests/explorers/bitcoin/blockexplorer.test.ts
+++ b/tests/explorers/bitcoin/blockexplorer.test.ts
@@ -21,7 +21,7 @@ describe('Blockexplorer Explorer test suite', function () {
     };
 
     it('should return the transaction data', function () {
-      expect(explorerApi.parsingFunction(mockResponse)).toEqual(assertionTransactionData);
+      expect(explorerApi.parsingFunction({ jsonResponse: mockResponse })).toEqual(assertionTransactionData);
     });
   });
 
@@ -29,7 +29,7 @@ describe('Blockexplorer Explorer test suite', function () {
     it('should throw the right error', async function () {
       mockResponse.confirmations = 0;
       await expect(async () => {
-        await explorerApi.parsingFunction(mockResponse);
+        await explorerApi.parsingFunction({ jsonResponse: mockResponse });
       }).rejects.toThrowError('Number of transaction confirmations were less than the minimum required, according to Blockexplorer API');
     });
   });

--- a/tests/explorers/bitcoin/blockstream.test.ts
+++ b/tests/explorers/bitcoin/blockstream.test.ts
@@ -21,7 +21,7 @@ describe('Blockstream Explorer test suite', function () {
     };
 
     it('should return the transaction data', function () {
-      expect(explorerApi.parsingFunction(mockResponse)).toEqual(assertionTransactionData);
+      expect(explorerApi.parsingFunction({ jsonResponse: mockResponse })).toEqual(assertionTransactionData);
     });
   });
 
@@ -29,7 +29,7 @@ describe('Blockstream Explorer test suite', function () {
     it('should throw the right error', async function () {
       mockResponse.status.confirmed = false;
       await expect(async () => {
-        await explorerApi.parsingFunction(mockResponse);
+        await explorerApi.parsingFunction({ jsonResponse: mockResponse });
       }).rejects.toThrowError('Number of transaction confirmations were less than the minimum required, according to Blockstream API');
     });
   });

--- a/tests/explorers/ethereum/blockcypher.test.ts
+++ b/tests/explorers/ethereum/blockcypher.test.ts
@@ -53,7 +53,7 @@ describe('Blockcypher Ethereum explorer test suite', function () {
         time: new Date('2018-06-01T20:47:55.000Z')
       };
 
-      const output: TransactionData = await BlockcyperETHApi.parsingFunction(responseData);
+      const output: TransactionData = await BlockcyperETHApi.parsingFunction({ jsonResponse: responseData });
 
       expect(output).toEqual(expectedOutput);
     });

--- a/tests/explorers/ethereum/etherscan.test.ts
+++ b/tests/explorers/ethereum/etherscan.test.ts
@@ -24,14 +24,14 @@ describe('Etherscan Explorer test suite', function () {
         time: new Date('2019-06-02T08:38:26.000Z')
       };
 
-      const res = await explorerApi.parsingFunction(mockResponse);
+      const res = await explorerApi.parsingFunction({ jsonResponse: mockResponse });
       expect(res).toEqual(assertionTransactionData);
     });
 
     describe('given the ether scan block cannot get retrieved', function () {
       it('should throw the right error', async function () {
         const stubRequest = sinon.stub(RequestServices, 'request').rejects();
-        await expect(explorerApi.parsingFunction(mockResponse))
+        await expect(explorerApi.parsingFunction({ jsonResponse: mockResponse }))
           .rejects.toThrow('Unable to get remote hash');
         stubRequest.restore();
       });

--- a/tests/explorers/explorer.test.ts
+++ b/tests/explorers/explorer.test.ts
@@ -7,7 +7,9 @@ import { getTransactionFromApi } from '../../src/explorers/explorer';
 import { TRANSACTION_APIS } from '../../src/constants/api';
 import { BLOCKCHAINS } from '../../src/constants/blockchains';
 import { ExplorerAPI } from '../../src/models/Explorers';
-import { getDefaultExplorers, overwriteDefaultExplorers } from '../../src/explorers';
+import { getDefaultExplorers, getRPCExplorers, overwriteDefaultExplorers } from '../../src/explorers';
+import * as ethRPCExplorer from '../../src/explorers/rpc/ethereum';
+import * as btcRPCExplorer from '../../src/explorers/rpc/bitcoin';
 
 describe('Blockchain Explorers test suite', function () {
   const fixtureTransactionId = '2378076e8e140012814e98a2b2cb1af07ec760b239c1d6d93ba54d658a010ecd';
@@ -156,6 +158,79 @@ describe('Blockchain Explorers test suite', function () {
           expect(output.bitcoin.length).toBe(4);
           expect(output.ethereum.length).toBe(2);
         });
+      });
+    });
+  });
+
+  describe('getRPCExplorers method', function () {
+    describe('given it is called with an eth custom explorer', function () {
+      it('should assign the ethereumRPCParsing function to retrieve the data', async function () {
+        const fixtureExplorer: ExplorerAPI = {
+          serviceURL: 'a-rpc-server.com',
+          chainType: 'eth',
+          priority: 0
+        };
+
+        const rpcFunctionName = 'ethereumRPCParsingFunction';
+        sinon.stub(ethRPCExplorer, rpcFunctionName).resolves(`${rpcFunctionName} was called` as any);
+
+        const explorers = getRPCExplorers([fixtureExplorer]);
+        const testOutput = await explorers.custom[0].getTxData('test');
+        expect(testOutput).toBe(`${rpcFunctionName} was called`);
+        sinon.restore();
+      });
+    });
+
+    describe('given it is called with an evm custom explorer', function () {
+      it('should assign the ethereumRPCParsing function to retrieve the data', async function () {
+        const fixtureExplorer: ExplorerAPI = {
+          serviceURL: 'a-rpc-server.com',
+          chainType: 'evm',
+          priority: 0
+        };
+
+        const rpcFunctionName = 'ethereumRPCParsingFunction';
+        sinon.stub(ethRPCExplorer, rpcFunctionName).resolves(`${rpcFunctionName} was called` as any);
+
+        const explorers = getRPCExplorers([fixtureExplorer]);
+        const testOutput = await explorers.custom[0].getTxData('test');
+        expect(testOutput).toBe(`${rpcFunctionName} was called`);
+        sinon.restore();
+      });
+    });
+
+    describe('given it is called with a btc custom explorer', function () {
+      it('should assign the bitcoinRPCParsingFunction to retrieve the data', async function () {
+        const fixtureExplorer: ExplorerAPI = {
+          serviceURL: 'a-rpc-server.com',
+          chainType: 'btc',
+          priority: 0
+        };
+
+        const rpcFunctionName = 'bitcoinRPCParsingFunction';
+        sinon.stub(btcRPCExplorer, rpcFunctionName).resolves(`${rpcFunctionName} was called` as any);
+
+        const explorers = getRPCExplorers([fixtureExplorer]);
+        const testOutput = await explorers.custom[0].getTxData('test', '' as any);
+        expect(testOutput).toBe(`${rpcFunctionName} was called`);
+        sinon.restore();
+      });
+    });
+
+    describe('given the chain type is not provided', function () {
+      it('should assign the ethereumRPCParsingFunction to retrieve the data', async function () {
+        const fixtureExplorer: ExplorerAPI = {
+          serviceURL: 'a-rpc-server.com',
+          priority: 0
+        };
+
+        const rpcFunctionName = 'ethereumRPCParsingFunction';
+        sinon.stub(ethRPCExplorer, rpcFunctionName).resolves(`${rpcFunctionName} was called` as any);
+
+        const explorers = getRPCExplorers([fixtureExplorer]);
+        const testOutput = await explorers.custom[0].getTxData('test');
+        expect(testOutput).toBe(`${rpcFunctionName} was called`);
+        sinon.restore();
       });
     });
   });

--- a/tests/explorers/explorer.test.ts
+++ b/tests/explorers/explorer.test.ts
@@ -240,6 +240,24 @@ describe('Blockchain Explorers test suite', function () {
         sinon.restore();
       });
     });
+
+    describe('given the parsing function is provided', function () {
+      it('should use the provided function to retrieve the data', async function () {
+        const fixtureExplorer: ExplorerAPI = {
+          serviceURL: 'a-rpc-server.com',
+          priority: 0,
+          parsingFunction: () => 'custom function was called' as any
+        };
+
+        const rpcFunctionName = 'ethereumRPCParsingFunction';
+        sinon.stub(ethRPCExplorer, rpcFunctionName).resolves(`${rpcFunctionName} was called` as any);
+
+        const explorers = getRPCExplorers([fixtureExplorer]);
+        const testOutput = await explorers.custom[0].getTxData('test');
+        expect(testOutput).toBe('custom function was called');
+        sinon.restore();
+      });
+    });
   });
 
   describe('prepareExplorerAPIs function', function () {

--- a/tests/explorers/rpc/bitcoin.test.ts
+++ b/tests/explorers/rpc/bitcoin.test.ts
@@ -1,0 +1,26 @@
+import sinon from 'sinon';
+import * as request from '../../../src/services/request';
+import { bitcoinRPCParsingFunction } from '../../../src/explorers/rpc/bitcoin';
+
+const getRawTransactionResponse = '{"result":{"txid":"d75b7a5bdb3d5244b753e6b84e987267cfa4ffa7a532a2ed49ad3848be1d82f8","hash":"d75b7a5bdb3d5244b753e6b84e987267cfa4ffa7a532a2ed49ad3848be1d82f8","version":1,"size":266,"vsize":266,"weight":1064,"locktime":0,"vin":[{"txid":"cbe1a820fd0512607d9cd41f3020770abc4ce015efb332a38b17598d981d26b9","vout":0,"scriptSig":{"asm":"304402207296a8a444e26cac6e0ab51e37fe96b59d406cab8ae61ca27332914052d9541202204b53a96e8d0bfca15dd5729d4ebee242cfd712138f7ccc1ae22451ff99750144[ALL] 04fddb3f9b745cb9dd54007164462597e607735cfe56baeef5a0b876c8bd16ee6115e3c77e2f74dc8129362e8c72e8dc4c27f4991f714754a57fd969f50e774e3d","hex":"47304402207296a8a444e26cac6e0ab51e37fe96b59d406cab8ae61ca27332914052d9541202204b53a96e8d0bfca15dd5729d4ebee242cfd712138f7ccc1ae22451ff99750144014104fddb3f9b745cb9dd54007164462597e607735cfe56baeef5a0b876c8bd16ee6115e3c77e2f74dc8129362e8c72e8dc4c27f4991f714754a57fd969f50e774e3d"},"sequence":4294967295}],"vout":[{"value":1.74630942,"n":0,"scriptPubKey":{"asm":"OP_DUP OP_HASH160 7fe4deec11117531349fc17d1217845fedf6e989 OP_EQUALVERIFY OP_CHECKSIG","hex":"76a9147fe4deec11117531349fc17d1217845fedf6e98988ac","reqSigs":1,"type":"pubkeyhash","addresses":["msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj"]}},{"value":0.00000000,"n":1,"scriptPubKey":{"asm":"OP_RETURN f029b45bb1a7b1f0b970f6de35344b73cccd16177b4c037acbc2541c7fc27078","hex":"6a20f029b45bb1a7b1f0b970f6de35344b73cccd16177b4c037acbc2541c7fc27078","type":"nulldata"}}],"hex":"0100000001b9261d988d59178ba332b3ef15e04cbc0a7720301fd49c7d601205fd20a8e1cb000000008a47304402207296a8a444e26cac6e0ab51e37fe96b59d406cab8ae61ca27332914052d9541202204b53a96e8d0bfca15dd5729d4ebee242cfd712138f7ccc1ae22451ff99750144014104fddb3f9b745cb9dd54007164462597e607735cfe56baeef5a0b876c8bd16ee6115e3c77e2f74dc8129362e8c72e8dc4c27f4991f714754a57fd969f50e774e3dffffffff021ea8680a000000001976a9147fe4deec11117531349fc17d1217845fedf6e98988ac0000000000000000226a20f029b45bb1a7b1f0b970f6de35344b73cccd16177b4c037acbc2541c7fc2707800000000","blockhash":"0000000000000ce580a03ccdbd79b9a8c252eb6ab0741b196fcea81f1b47ca90","confirmations":746253,"time":1498774229,"blocktime":1498774229},"error":null,"id":"rpctest"}';
+
+describe('Bitcoin RPC response parsing test suite', function () {
+  describe('given it is called with a transactionId and a server URL', function () {
+    it('should retrieve the transaction data', async function () {
+      const requestStub: sinon.SinonStub = sinon.stub(request, 'request');
+      const transactionId = 'd75b7a5bdb3d5244b753e6b84e987267cfa4ffa7a532a2ed49ad3848be1d82f8';
+      const serverUrl = 'a-btc-rpc-url.com';
+
+      requestStub.onCall(0).resolves(getRawTransactionResponse);
+
+      const output = await bitcoinRPCParsingFunction(serverUrl, transactionId);
+      expect(output).toEqual({
+        remoteHash: 'f029b45bb1a7b1f0b970f6de35344b73cccd16177b4c037acbc2541c7fc27078',
+        issuingAddress: 'msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj',
+        time: new Date('2017-06-29T22:10:29.000Z'),
+        revokedAddresses: ['msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj']
+      });
+      requestStub.restore();
+    });
+  });
+});

--- a/tests/explorers/rpc/bitcoin.test.ts
+++ b/tests/explorers/rpc/bitcoin.test.ts
@@ -9,11 +9,11 @@ describe('Bitcoin RPC response parsing test suite', function () {
     it('should retrieve the transaction data', async function () {
       const requestStub: sinon.SinonStub = sinon.stub(request, 'request');
       const transactionId = 'd75b7a5bdb3d5244b753e6b84e987267cfa4ffa7a532a2ed49ad3848be1d82f8';
-      const serverUrl = 'a-btc-rpc-url.com';
+      const serviceUrl = 'a-btc-rpc-url.com';
 
       requestStub.onCall(0).resolves(getRawTransactionResponse);
 
-      const output = await bitcoinRPCParsingFunction(serverUrl, transactionId);
+      const output = await bitcoinRPCParsingFunction({ serviceUrl, transactionId });
       expect(output).toEqual({
         remoteHash: 'f029b45bb1a7b1f0b970f6de35344b73cccd16177b4c037acbc2541c7fc27078',
         issuingAddress: 'msBCHdwaQ7N2ypBYupkp6uNxtr9Pg76imj',

--- a/tests/explorers/rpc/ethereum.test.ts
+++ b/tests/explorers/rpc/ethereum.test.ts
@@ -11,7 +11,7 @@ describe('Ethereum RPC response parsing test suite', function () {
     it('should retrieve the transaction data', async function () {
       const requestStub: sinon.SinonStub = sinon.stub(request, 'request');
       const transactionId = 'ef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa';
-      const serverUrl = 'https://rpc-mumbai.maticvigil.com/';
+      const serverUrl = 'https://an-evm-rpc-explorer.com/';
 
       requestStub.onCall(0).resolves(getByHashResponse);
       requestStub.onCall(1).resolves(blockByNumberResponse);
@@ -23,6 +23,8 @@ describe('Ethereum RPC response parsing test suite', function () {
         time: new Date('2020-09-22T14:20:31.000Z'),
         revokedAddresses: []
       });
+
+      requestStub.restore();
     });
   });
 });

--- a/tests/explorers/rpc/ethereum.test.ts
+++ b/tests/explorers/rpc/ethereum.test.ts
@@ -1,0 +1,18 @@
+import { ethereumRPCParsingFunction } from '../../../src/explorers/rpc/ethereum';
+
+describe('Ethereum RPC response parsing test suite', function () {
+  describe('given it is called with a transactionId and a server URL', function () {
+    it('should retrieve the transaction data', async function () {
+      const transactionId = '0xef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa';
+      const serverUrl = 'https://rpc-mumbai.maticvigil.com/';
+
+      const output = await ethereumRPCParsingFunction(serverUrl, transactionId);
+      expect(output).toEqual({
+        remoteHash: '7122cbe07bafd8c243e8c2b684b38e32cc2493365d7ced1e7f1160cf99be835a',
+        issuingAddress: '0x11f1089baceaa98dbe22c079c9df1e2338af22e1',
+        time: new Date('2020-09-22T14:20:31.000Z'),
+        revokedAddresses: []
+      });
+    });
+  });
+});

--- a/tests/explorers/rpc/ethereum.test.ts
+++ b/tests/explorers/rpc/ethereum.test.ts
@@ -1,10 +1,20 @@
+import sinon from 'sinon';
 import { ethereumRPCParsingFunction } from '../../../src/explorers/rpc/ethereum';
+import * as request from '../../../src/services/request';
+
+const getByHashResponse = '{"jsonrpc":"2.0","id":"getbyhash","result":{"blockHash":"0xfb6e2f57468cdec12becc9b4dec4844e2efa7cc1ac87965a871c7d71133133dd","blockNumber":"0x46022a","from":"0x11f1089baceaa98dbe22c079c9df1e2338af22e1","gas":"0x5408","gasPrice":"0x3b9aca00","hash":"0xef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa","input":"0x7122cbe07bafd8c243e8c2b684b38e32cc2493365d7ced1e7f1160cf99be835a","nonce":"0x7","to":"0x11f1089baceaa98dbe22c079c9df1e2338af22e1","transactionIndex":"0x0","value":"0x0","v":"0x27125","r":"0x92d2c281250f0241c26905b73a95c47b7757e05bd78bdc70b5265633929e9d3b","s":"0x2a22306868dca1c9c13b91d4dcedc9629071247085202e47de0fe525d963cd9"}}';
+
+const blockByNumberResponse = '{"jsonrpc":"2.0","id":"blockbynumber","result":{"difficulty":"0x6","extraData":"0xd58301091083626f7286676f312e3133856c696e75780000000000000000000093a9198764b0db11a926e4edc7551ed22ce003321c138b50c9b91b4279f4afad38760444e5c0dc1fad9ed35d91486a45d05ba412c70ebbb3abfefc5a5151557b01","gasLimit":"0x1312d00","gasUsed":"0x5408","hash":"0xfb6e2f57468cdec12becc9b4dec4844e2efa7cc1ac87965a871c7d71133133dd","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000010000000000000000000000000000000000000000000000000800000000000800000000100000000004000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000080000000000000000000200000000000000000000000000000000000000000000000000000000000004000000000000000000001000000000000000000000000000000100040000000000000000000000000000000000000000000000000000010000000000000100000","miner":"0x0000000000000000000000000000000000000000","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","number":"0x46022a","parentHash":"0x621e7cbb6e890c895af6250bd625d1ad2236d6c70aa6a1d3fd5a776b3db8109f","receiptsRoot":"0xc0eadd0b3b85cac44db93f86dd8d542020804132b95dbfb66570aae70c07f27f","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x2ed","stateRoot":"0xfaff3d6e18f470fcee6d6fbf1322bfdec6d2604dba33305bbdc098582d491edd","timestamp":"0x5f6a082f","totalDifficulty":"0x173cc81","transactions":[{"blockHash":"0xfb6e2f57468cdec12becc9b4dec4844e2efa7cc1ac87965a871c7d71133133dd","blockNumber":"0x46022a","from":"0x11f1089baceaa98dbe22c079c9df1e2338af22e1","gas":"0x5408","gasPrice":"0x3b9aca00","hash":"0xef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa","input":"0x7122cbe07bafd8c243e8c2b684b38e32cc2493365d7ced1e7f1160cf99be835a","nonce":"0x7","to":"0x11f1089baceaa98dbe22c079c9df1e2338af22e1","transactionIndex":"0x0","value":"0x0","v":"0x27125","r":"0x92d2c281250f0241c26905b73a95c47b7757e05bd78bdc70b5265633929e9d3b","s":"0x2a22306868dca1c9c13b91d4dcedc9629071247085202e47de0fe525d963cd9"}],"transactionsRoot":"0x91ed5bfce4b07bfae7174a05fed72e523ebe585bb970d2154d9c06af0a1ea22d","uncles":[]}}';
 
 describe('Ethereum RPC response parsing test suite', function () {
   describe('given it is called with a transactionId and a server URL', function () {
     it('should retrieve the transaction data', async function () {
-      const transactionId = '0xef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa';
+      const requestStub: sinon.SinonStub = sinon.stub(request, 'request');
+      const transactionId = 'ef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa';
       const serverUrl = 'https://rpc-mumbai.maticvigil.com/';
+
+      requestStub.onCall(0).resolves(getByHashResponse);
+      requestStub.onCall(1).resolves(blockByNumberResponse);
 
       const output = await ethereumRPCParsingFunction(serverUrl, transactionId);
       expect(output).toEqual({

--- a/tests/explorers/rpc/ethereum.test.ts
+++ b/tests/explorers/rpc/ethereum.test.ts
@@ -11,12 +11,12 @@ describe('Ethereum RPC response parsing test suite', function () {
     it('should retrieve the transaction data', async function () {
       const requestStub: sinon.SinonStub = sinon.stub(request, 'request');
       const transactionId = 'ef59c07bed26d473925e688ec4da2211981820dc1167427ef34d2a2e6f45b8fa';
-      const serverUrl = 'https://an-evm-rpc-explorer.com/';
+      const serviceUrl = 'https://an-evm-rpc-explorer.com/';
 
       requestStub.onCall(0).resolves(getByHashResponse);
       requestStub.onCall(1).resolves(blockByNumberResponse);
 
-      const output = await ethereumRPCParsingFunction(serverUrl, transactionId);
+      const output = await ethereumRPCParsingFunction({ serviceUrl, transactionId });
       expect(output).toEqual({
         remoteHash: '7122cbe07bafd8c243e8c2b684b38e32cc2493365d7ced1e7f1160cf99be835a',
         issuingAddress: '0x11f1089baceaa98dbe22c079c9df1e2338af22e1',

--- a/tests/helpers/getChain.test.ts
+++ b/tests/helpers/getChain.test.ts
@@ -86,22 +86,6 @@ describe('getChain test suite', function () {
           expect(result).toEqual(chainAssertion);
         });
       });
-
-      describe('and the chain is not supported', function () {
-        it('should throw', function () {
-          const fixtureSignature: DecodedProof = {
-            anchors: [
-              'blink:blabla:rinkeby:0xfaea9061b06ff532d96ad91bab89fdfab900ae7d4524161431dc88318216435a'
-            ],
-            targetHash: 'a-target-hash',
-            path: [{ left: 'a-path' }],
-            merkleRoot: 'a-merkle-root'
-          };
-          expect(() => {
-            getChain(fixtureSignature);
-          }).toThrow('Unsupported anchoring chain.');
-        });
-      });
     });
   });
 

--- a/tests/helpers/lookForTx.test.ts
+++ b/tests/helpers/lookForTx.test.ts
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import lookForTx, { getExplorersByChain, prepareExplorerAPIs } from '../../src/helpers/lookForTx';
+import lookForTx, { getExplorersByChain } from '../../src/helpers/lookForTx';
 import { SupportedChains } from '../../src/constants/blockchains';
 import { getDefaultExplorers, TExplorerAPIs } from '../../src/explorers';
 import { TransactionData } from '../../src/models/TransactionData';
@@ -132,38 +132,6 @@ describe('getExplorersByChain test suite', function () {
         // because they are wrapped, we don't necessarily have the deep nature of the result, so we use a weak test to ensure
         expect(selectedSelectors.length).toBe(4);
       });
-    });
-  });
-});
-
-describe('prepareExplorerAPIs function', function () {
-  describe('given custom explorers are provided', function () {
-    it('should return the explorers object with the custom explorers', function () {
-      const fixtureCustomExplorerAPI: ExplorerAPI[] = [{
-        serviceURL: 'https://explorer-example.com',
-        priority: 0,
-        parsingFunction: (): TransactionData => {
-          return {
-            remoteHash: 'a',
-            issuingAddress: 'b',
-            time: 'c',
-            revokedAddresses: ['d']
-          };
-        }
-      }];
-      const expectedExplorers: TExplorerAPIs = getDefaultExplorers();
-      expectedExplorers.custom = explorerFactory(fixtureCustomExplorerAPI);
-      const output = prepareExplorerAPIs(fixtureCustomExplorerAPI);
-      expect(JSON.stringify(output)).toEqual(JSON.stringify(expectedExplorers));
-    });
-  });
-
-  describe('given no explorers are provided', function () {
-    it('should return only the default explorers', function () {
-      const expectedExplorers: TExplorerAPIs = getDefaultExplorers();
-      expectedExplorers.custom = [];
-      const output = prepareExplorerAPIs([]);
-      expect(JSON.stringify(output)).toEqual(JSON.stringify(expectedExplorers));
     });
   });
 });

--- a/tests/helpers/lookForTx.test.ts
+++ b/tests/helpers/lookForTx.test.ts
@@ -131,5 +131,22 @@ describe('getExplorersByChain test suite', function () {
         expect(selectedSelectors.length).toBe(4);
       });
     });
+
+    describe('in all other cases', function () {
+      it('should return the custom explorers', function () {
+        const explorers = {
+          ...getDefaultExplorers(),
+          custom: [
+            {
+              getTxData: () => '' as any,
+              priority: 0
+            }
+          ]
+        };
+        const selectedSelectors = getExplorersByChain('Matic' as any, explorers);
+        // because they are wrapped, we don't necessarily have the deep nature of the result, so we use a weak test to ensure
+        expect(selectedSelectors.length).toBe(1);
+      });
+    });
   });
 });

--- a/tests/helpers/lookForTx.test.ts
+++ b/tests/helpers/lookForTx.test.ts
@@ -161,6 +161,7 @@ describe('prepareExplorerAPIs function', function () {
   describe('given no explorers are provided', function () {
     it('should return only the default explorers', function () {
       const expectedExplorers: TExplorerAPIs = getDefaultExplorers();
+      expectedExplorers.custom = [];
       const output = prepareExplorerAPIs([]);
       expect(JSON.stringify(output)).toEqual(JSON.stringify(expectedExplorers));
     });

--- a/tests/helpers/lookForTx.test.ts
+++ b/tests/helpers/lookForTx.test.ts
@@ -4,8 +4,6 @@ import { SupportedChains } from '../../src/constants/blockchains';
 import { getDefaultExplorers, TExplorerAPIs } from '../../src/explorers';
 import { TransactionData } from '../../src/models/TransactionData';
 import CONFIG from '../../src/constants/config';
-import { ExplorerAPI } from '../../src/models/Explorers';
-import { explorerFactory } from '../../src/explorers/explorer';
 
 describe('lookForTx test suite', function () {
   const MOCK_TRANSACTION_ID = 'mock-transaction-id';


### PR DESCRIPTION
Leverage explorerAPIs and use RPC explorers to allow looking up other chains than BTC and ETH.
Things to improve:
- I think we would want to allow the use of RPCs for BTC and ETH, which I believe wouldn't work at this point
- ~~improve TS signature of parsingFunction. Or unify them, or something. It's not clean at this point but I don't want to bloat this PR, since it works when running~~.
- try and reduce the API surface of `parsingFunction` by trying to merge the `serverUrl` properties with `key` and `keyPropertyName`: essentially forcing the url to be well-formed with identifiers, if possible.