### PR TITLE
Feat/more integration with jsonld

### DIFF
--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -23,7 +23,7 @@ export interface VCDocument {
 
 export interface MerkleProof2019API {
   options?: MerkleProof2019Options;
-  type?: 'MerkleProof2019';
+  type?: 'MerkleProof2019' | string;
   issuer?: any; // TODO: define issuer type
   verificationMethod?: string;
   document: VCDocument;
@@ -74,6 +74,7 @@ export class MerkleProof2019 extends (LinkedDataProof as any) {
       throw new Error('A document signed by MerkleProof2019 is required for the verification process.');
     }
 
+    this.type = type;
     this.issuer = issuer;
     this.verificationMethod = verificationMethod;
     this.document = document;

--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -92,12 +92,12 @@ export class MerkleProof2019 extends (LinkedDataProof as any) {
     this.proof = base58Decoder.decode();
   }
 
-  async verifyProof (): Promise<MerkleProof2019VerificationResult> {
+  async verifyProof ({ documentLoader = null }): Promise<MerkleProof2019VerificationResult> {
     let verified: boolean;
     let error: string = '';
     try {
       this.validateTransactionId();
-      await this.computeLocalHash();
+      await this.computeLocalHash(documentLoader);
       await this.fetchTransactionData();
       this.compareHashes();
       this.confirmMerkleRoot();
@@ -120,8 +120,8 @@ export class MerkleProof2019 extends (LinkedDataProof as any) {
     ensureHashesEqual(this.localDocumentHash, this.proof.targetHash);
   }
 
-  private async computeLocalHash (): Promise<void> {
-    this.localDocumentHash = await computeLocalHash(this.document);
+  private async computeLocalHash (documentLoader): Promise<void> {
+    this.localDocumentHash = await computeLocalHash(this.document, documentLoader);
   }
 
   private getChain (): void {

--- a/src/MerkleProof2019.ts
+++ b/src/MerkleProof2019.ts
@@ -93,7 +93,7 @@ export class MerkleProof2019 extends (LinkedDataProof as any) {
     this.proof = base58Decoder.decode();
   }
 
-  async verifyProof ({ documentLoader = null }): Promise<MerkleProof2019VerificationResult> {
+  async verifyProof ({ documentLoader } = { documentLoader: (url): any => {} }): Promise<MerkleProof2019VerificationResult> {
     let verified: boolean;
     let error: string = '';
     try {

--- a/src/inspectors/computeLocalHash.ts
+++ b/src/inspectors/computeLocalHash.ts
@@ -1,4 +1,5 @@
 import jsonld from 'jsonld';
+import JsonLdError from 'jsonld/lib/JsonLdError';
 import sha256 from 'sha256';
 import { CONTEXTS as ContextsMap } from '../constants/contexts';
 import { toUTF8Data } from '../utils/data';
@@ -58,11 +59,15 @@ export default async function computeLocalHash (document: any): Promise<string> 
   }
 
   return new Promise((resolve, reject) => {
-    jsonld.normalize(theDocument, normalizeArgs, (err, normalized) => {
+    jsonld.normalize(theDocument, normalizeArgs, (err: JsonLdError, normalized) => {
       const isErr = !!err;
       if (isErr) {
         reject(
-          new Error(`Failed to normalize document: ${err as string}`)
+          new JsonLdError(
+            'Failed to normalize document',
+            err.name,
+            err.details
+          )
         );
       } else {
         resolve(sha256(toUTF8Data(normalized)));

--- a/src/inspectors/computeLocalHash.ts
+++ b/src/inspectors/computeLocalHash.ts
@@ -29,7 +29,7 @@ function setJsonLdDocumentLoader (): any { // not typed by jsonld
   return jsonld.documentLoaders.node();
 }
 
-export default async function computeLocalHash (document: any, documentLoader?: any): Promise<string> { // TODO: define VC type
+export default async function computeLocalHash (document: any, documentLoader = (url: string): any => null): Promise<string> { // TODO: define VC type
   const expandContext = document['@context'];
   const theDocument = JSON.parse(JSON.stringify(document));
 

--- a/src/inspectors/computeLocalHash.ts
+++ b/src/inspectors/computeLocalHash.ts
@@ -29,7 +29,7 @@ function setJsonLdDocumentLoader (): any { // not typed by jsonld
   return jsonld.documentLoaders.node();
 }
 
-export default async function computeLocalHash (document: any): Promise<string> { // TODO: define VC type
+export default async function computeLocalHash (document: any, documentLoader?: any): Promise<string> { // TODO: define VC type
   const expandContext = document['@context'];
   const theDocument = JSON.parse(JSON.stringify(document));
 
@@ -39,7 +39,12 @@ export default async function computeLocalHash (document: any): Promise<string> 
   }
 
   const jsonldDocumentLoader = setJsonLdDocumentLoader();
-  const customLoader = function (url, callback): any { // Not typed by JSONLD
+  const customLoader = async function (url, callback): Promise<any> { // Not typed by JSONLD
+    const context = await documentLoader(url);
+    if (context) {
+      return callback(null, context);
+    }
+
     if (url in CONTEXTS) {
       return callback(null, {
         contextUrl: null,
@@ -58,10 +63,11 @@ export default async function computeLocalHash (document: any): Promise<string> 
     normalizeArgs.expandContext = expandContext;
   }
 
-  return new Promise((resolve, reject) => {
+  return await new Promise((resolve, reject) => {
     jsonld.normalize(theDocument, normalizeArgs, (err: JsonLdError, normalized) => {
       const isErr = !!err;
       if (isErr) {
+        console.log('error', err);
         reject(
           new JsonLdError(
             'Failed to normalize document',

--- a/tests/MerkleProof2019.test.ts
+++ b/tests/MerkleProof2019.test.ts
@@ -73,6 +73,14 @@ describe('MerkleProof2019 test suite', function () {
       });
     });
 
+    describe('given the type is passed', function () {
+      it('should register the type', function () {
+        const fixtureType: string = 'fixtureType';
+        const instance = new MerkleProof2019({ type: fixtureType, document: blockcertsV3Fixture });
+        expect(instance.type).toBe(fixtureType);
+      });
+    });
+
     describe('verifyProof method', function () {
       describe('when the process is successful', function () {
         let result: MerkleProof2019VerificationResult;
@@ -103,6 +111,14 @@ describe('MerkleProof2019 test suite', function () {
           expect(result).toEqual({
             verified: true,
             error: ''
+          });
+        });
+
+        describe('and it is called with a documentLoader', function () {
+          it('should call the documentLoader method', async function () {
+            const stubLoader: sinon.SinonStub = sinon.stub().resolves(null);
+            await instance.verifyProof({ documentLoader: stubLoader });
+            expect(stubLoader.callCount > 0).toBe(true);
           });
         });
       });

--- a/tests/inspectors/computeLocalHash.test.ts
+++ b/tests/inspectors/computeLocalHash.test.ts
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import jsonld from 'jsonld';
+import JsonLdError from 'jsonld/lib/JsonLdError';
 import blockcertsV3Fixture, { documentHash } from '../fixtures/blockcerts-v3';
 import computeLocalHash from '../../src/inspectors/computeLocalHash';
 
@@ -13,17 +14,31 @@ describe('computeLocalHash test suite', function () {
 
   describe('given the normalization of the document fails', function () {
     it('should reject with an error', async function () {
+      const mockJsonLdError: JsonLdError = {
+        message: 'Failed',
+        name: 'jsonld.InvalidUrl',
+        details: {
+          code: 'loading document failed',
+          url: 'https://blockcerts.org/credentials/v1',
+          httpStatusCode: 404
+        }
+      };
       const normalizeStub: sinon.SinonStub = sinon.stub(jsonld, 'normalize')
         .callsFake(
-          function (fakeDoc: any, fakeArgs: any, cb: (err: string, document: any) => any) {
+          function (fakeDoc: any, fakeArgs: any, cb: (err: JsonLdError, document: any) => any) {
             // https://github.com/standard/standard/issues/1352 silly people trying to be too smart
             // eslint-disable-next-line standard/no-callback-literal
-            cb('This is an error', {});
+            cb(mockJsonLdError, {});
           }
         );
-      await expect(async () => {
+
+      try {
         await computeLocalHash(blockcertsV3Fixture);
-      }).rejects.toThrow('Failed to normalize document: This is an error');
+      } catch (e) {
+        expect(e.message).toBe('Failed to normalize document');
+        expect(e.name).toBe(mockJsonLdError.name);
+        expect(e.details).toEqual(mockJsonLdError.details);
+      }
       normalizeStub.restore();
     });
   });

--- a/tests/inspectors/computeLocalHash.test.ts
+++ b/tests/inspectors/computeLocalHash.test.ts
@@ -12,6 +12,14 @@ describe('computeLocalHash test suite', function () {
     });
   });
 
+  describe('given it is provided with a documentLoader', function () {
+    it('should call the documentLoader', async function () {
+      const stubLoader = sinon.stub().resolves(null);
+      await computeLocalHash(blockcertsV3Fixture, stubLoader);
+      expect(stubLoader.callCount > 0).toBe(true);
+    });
+  });
+
   describe('given the normalization of the document fails', function () {
     it('should reject with an error', async function () {
       const mockJsonLdError: JsonLdError = {


### PR DESCRIPTION
- use documentLoader as sent by jsonld
- map errors to jsonld to avoid breakage
- allow MerkleProof2019 proof to be named with a different type (case vaultie)