### PR TITLE
fix(lds-merkle-proof-2019): bump up latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@blockcerts/explorer-lookup": "^1.3.0",
         "@trust/keyto": "^1.0.1",
-        "@vaultie/lds-merkle-proof-2019": "0.0.8",
+        "@vaultie/lds-merkle-proof-2019": "^0.0.9",
         "bitcoinjs-lib": "^6.0.2",
         "bs58": "^4.0.1",
         "core-js": "^3.7.0",
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@vaultie/lds-merkle-proof-2019": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.8.tgz",
-      "integrity": "sha512-Tn+M9Vbj7Ie0ab4jqjWWBXZ4RDWn+cHWf+drSgbQgwtEs4h0hGvaNTEzSNcChOndC/XxzetmfK+XqVryfv2f7w==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.9.tgz",
+      "integrity": "sha512-ZatItEvNBJeAF8Tb+4vrhtj+8WdY65OnteY7KaKB2SIUG8ZSyQ1lHWTyJC/zlPknIzU6fJe0MIdG3COkjAzrsg==",
       "dependencies": {
         "ajv": "^6.10.2",
         "cbor": "^5.0.1",
@@ -12311,7 +12311,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -13562,7 +13562,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -14087,9 +14088,9 @@
       }
     },
     "@vaultie/lds-merkle-proof-2019": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.8.tgz",
-      "integrity": "sha512-Tn+M9Vbj7Ie0ab4jqjWWBXZ4RDWn+cHWf+drSgbQgwtEs4h0hGvaNTEzSNcChOndC/XxzetmfK+XqVryfv2f7w==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@vaultie/lds-merkle-proof-2019/-/lds-merkle-proof-2019-0.0.9.tgz",
+      "integrity": "sha512-ZatItEvNBJeAF8Tb+4vrhtj+8WdY65OnteY7KaKB2SIUG8ZSyQ1lHWTyJC/zlPknIzU6fJe0MIdG3COkjAzrsg==",
       "requires": {
         "ajv": "^6.10.2",
         "cbor": "^5.0.1",
@@ -14116,7 +14117,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -15296,7 +15298,8 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
       "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-with-typescript": {
       "version": "19.0.1",
@@ -15470,7 +15473,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
       "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -16091,7 +16095,7 @@
     },
     "hash-base": {
       "version": "git+ssh://git@github.com/blockchain-certificates/hash-base.git#5b62872dbec16648c86246c4cafc263773250e91",
-      "from": "hash-base@https://github.com/blockchain-certificates/hash-base.git",
+      "from": "hash-base@github:blockchain-certificates/hash-base",
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "npm:vite-compatible-readable-stream@^3.6.1",
@@ -17032,7 +17036,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.0.0",
@@ -21699,7 +21704,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true
+      "devOptional": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@blockcerts/explorer-lookup": "^1.3.0",
     "@trust/keyto": "^1.0.1",
-    "@vaultie/lds-merkle-proof-2019": "0.0.8",
+    "@vaultie/lds-merkle-proof-2019": "^0.0.9",
     "bitcoinjs-lib": "^6.0.2",
     "bs58": "^4.0.1",
     "core-js": "^3.7.0",


### PR DESCRIPTION
I want to use @vaultie/lds-merkle-proof-2019 v0.0.9 or higher with goerli and sepolia support added.

- https://github.com/vaultie/lds-merkle-proof-2019/commit/74f4bc513ceb91f70e6ade248fb72079b565ce23
- https://github.com/vaultie/lds-merkle-proof-2019/commit/f44f7979ee6dfd7e44456aa95fedc50f437ff3df

This also relates to the following PR.
https://github.com/blockchain-certificates/blockcerts-verifier/pull/1348